### PR TITLE
Fix NullPointerException exception when not having a description on a faction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,37 +1,39 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.dynmap</groupId>
-  <artifactId>Dynmap-Factions</artifactId>
-  <version>0.91</version>
-  	<properties>
-	   	<timestamp>${maven.build.timestamp}</timestamp>
-   		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>	
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.dynmap</groupId>
+	<artifactId>Dynmap-Factions</artifactId>
+	<version>0.91</version>
+	<properties>
+		<timestamp>${maven.build.timestamp}</timestamp>
+		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<BUILD_NUMBER>Dev${timestamp}</BUILD_NUMBER>
 	</properties>
-  
-    <build>
-  	  <resources>
-		<resource>
-		  <directory>src/main/resources</directory>
-		  <filtering>true</filtering>
-		  <includes>
-			<include>*.yml</include>
-			<include>*.txt</include>
-		  </includes>
-		</resource>
-		<resource>
-		  <directory>src/main/resources</directory>
-		  <filtering>false</filtering>
-		  <excludes>
-			<exclude>*.yml</exclude>
-			<exclude>*.txt</exclude>
-		  </excludes>
-		</resource>
-	  </resources>
-  
-  	<plugins>
- 			<plugin>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>*.yml</include>
+					<include>*.txt</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>*.yml</exclude>
+					<exclude>*.txt</exclude>
+				</excludes>
+			</resource>
+		</resources>
+
+		<plugins>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.0.2</version>
@@ -40,9 +42,9 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
-  	</plugins>
-  </build>
-     <repositories>
+		</plugins>
+	</build>
+	<repositories>
 		<repository>
 			<releases>
 			</releases>
@@ -60,31 +62,31 @@
 			<url>http://repo.mikeprimm.com/</url>
 		</repository>
 	</repositories>
-  
-  <dependencies>
-  	<dependency>
-  		<groupId>org.dynmap</groupId>
-  		<artifactId>dynmap-api</artifactId>
-  		<version>1.9</version>
-  	</dependency>
-  	<dependency>
-  		<groupId>org.bukkit</groupId>
-  		<artifactId>bukkit</artifactId>
-  		<version>1.7.10-R0.1-SNAPSHOT</version>
-  	</dependency>
-  	<dependency>
-  		<groupId>com.massivecraft</groupId>
-  		<artifactId>Factions</artifactId>
-  		<version>2.7.1</version>
-  		<scope>system</scope>
-  		<systemPath>${project.basedir}/Factions-2.7.1.jar</systemPath>
-  	</dependency>
-  	<dependency>
-  		<groupId>com.massivecraft</groupId>
-  		<artifactId>MassiveCore</artifactId>
-  		<version>2.7.1</version>
-  		<scope>system</scope>
-  		<systemPath>${project.basedir}/MassiveCore-2.7.1.jar</systemPath>
-  	</dependency>
-  </dependencies>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.dynmap</groupId>
+			<artifactId>dynmap-api</artifactId>
+			<version>1.9</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bukkit</groupId>
+			<artifactId>bukkit</artifactId>
+			<version>1.7.10-R0.1-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.massivecraft</groupId>
+			<artifactId>Factions</artifactId>
+			<version>2.7.1</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/Factions-2.7.1.jar</systemPath>
+		</dependency>
+		<dependency>
+			<groupId>com.massivecraft</groupId>
+			<artifactId>MassiveCore</artifactId>
+			<version>2.7.1</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/MassiveCore-2.7.1.jar</systemPath>
+		</dependency>
+	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,39 +1,37 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.dynmap</groupId>
-	<artifactId>Dynmap-Factions</artifactId>
-	<version>0.91</version>
-	<properties>
-		<timestamp>${maven.build.timestamp}</timestamp>
-		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.dynmap</groupId>
+  <artifactId>Dynmap-Factions</artifactId>
+  <version>0.91</version>
+  	<properties>
+	   	<timestamp>${maven.build.timestamp}</timestamp>
+   		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>	
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<BUILD_NUMBER>Dev${timestamp}</BUILD_NUMBER>
 	</properties>
-
-	<build>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-				<filtering>true</filtering>
-				<includes>
-					<include>*.yml</include>
-					<include>*.txt</include>
-				</includes>
-			</resource>
-			<resource>
-				<directory>src/main/resources</directory>
-				<filtering>false</filtering>
-				<excludes>
-					<exclude>*.yml</exclude>
-					<exclude>*.txt</exclude>
-				</excludes>
-			</resource>
-		</resources>
-
-		<plugins>
-			<plugin>
+  
+    <build>
+  	  <resources>
+		<resource>
+		  <directory>src/main/resources</directory>
+		  <filtering>true</filtering>
+		  <includes>
+			<include>*.yml</include>
+			<include>*.txt</include>
+		  </includes>
+		</resource>
+		<resource>
+		  <directory>src/main/resources</directory>
+		  <filtering>false</filtering>
+		  <excludes>
+			<exclude>*.yml</exclude>
+			<exclude>*.txt</exclude>
+		  </excludes>
+		</resource>
+	  </resources>
+  
+  	<plugins>
+ 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.0.2</version>
@@ -42,9 +40,9 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
-		</plugins>
-	</build>
-	<repositories>
+  	</plugins>
+  </build>
+     <repositories>
 		<repository>
 			<releases>
 			</releases>
@@ -62,31 +60,31 @@
 			<url>http://repo.mikeprimm.com/</url>
 		</repository>
 	</repositories>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.dynmap</groupId>
-			<artifactId>dynmap-api</artifactId>
-			<version>1.9</version>
-		</dependency>
-		<dependency>
-			<groupId>org.bukkit</groupId>
-			<artifactId>bukkit</artifactId>
-			<version>1.7.10-R0.1-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>com.massivecraft</groupId>
-			<artifactId>Factions</artifactId>
-			<version>2.7.1</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/Factions-2.7.1.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.massivecraft</groupId>
-			<artifactId>MassiveCore</artifactId>
-			<version>2.7.1</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/MassiveCore-2.7.1.jar</systemPath>
-		</dependency>
-	</dependencies>
+  
+  <dependencies>
+  	<dependency>
+  		<groupId>org.dynmap</groupId>
+  		<artifactId>dynmap-api</artifactId>
+  		<version>1.9</version>
+  	</dependency>
+  	<dependency>
+  		<groupId>org.bukkit</groupId>
+  		<artifactId>bukkit</artifactId>
+  		<version>1.7.10-R0.1-SNAPSHOT</version>
+  	</dependency>
+  	<dependency>
+  		<groupId>com.massivecraft</groupId>
+  		<artifactId>Factions</artifactId>
+  		<version>2.7.1</version>
+  		<scope>system</scope>
+  		<systemPath>${project.basedir}/Factions-2.7.1.jar</systemPath>
+  	</dependency>
+  	<dependency>
+  		<groupId>com.massivecraft</groupId>
+  		<artifactId>MassiveCore</artifactId>
+  		<version>2.7.1</version>
+  		<scope>system</scope>
+  		<systemPath>${project.basedir}/MassiveCore-2.7.1.jar</systemPath>
+  	</dependency>
+  </dependencies>
 </project>

--- a/src/main/java/org/dynmap/factions/DynmapFactionsPlugin.java
+++ b/src/main/java/org/dynmap/factions/DynmapFactionsPlugin.java
@@ -204,7 +204,12 @@ public class DynmapFactionsPlugin extends JavaPlugin {
     private String formatInfoWindow(Faction fact) {
         String v = "<div class=\"regioninfo\">"+infowindow+"</div>";
         v = v.replace("%regionname%", ChatColor.stripColor(fact.getName()));
-        v = v.replace("%description%", ChatColor.stripColor(fact.getDescription()));
+        
+        String description = fact.getDescription();
+
+        
+        v = v.replace("%description%", description == null ? "" : ChatColor.stripColor(description));
+        
         MPlayer adm = fact.getLeader();
         v = v.replace("%playerowners%", (adm!=null)?adm.getName():"");
         String res = "";


### PR DESCRIPTION
Fix for the following error by null checking description

java.lang.NullPointerException: null
        at java.lang.String.replace(String.java:2240) ~[?:1.8.0_262]
        at org.dynmap.factions.DynmapFactionsPlugin.formatInfoWindow(DynmapFactionsPlugin.java:207) ~[?:?]
        at org.dynmap.factions.DynmapFactionsPlugin.handleFactionOnWorld(DynmapFactionsPlugin.java:312) ~[?:?]
        at org.dynmap.factions.DynmapFactionsPlugin.updateFactions(DynmapFactionsPlugin.java:507) ~[?:?]
        at org.dynmap.factions.DynmapFactionsPlugin.access$000(DynmapFactionsPlugin.java:49) ~[?:?]
        at org.dynmap.factions.DynmapFactionsPlugin$FactionsUpdate.run(DynmapFactionsPlugin.java:133) ~[?:?]
        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftTask.run(CraftTask.java:76) ~[spigot.jar:git-Spigot-79a30d7-acbc348]
        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:361) [spigot.jar:git-Spigot-79a30d7-acbc348]
        at net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:739) [spigot.jar:git-Spigot-79a30d7-acbc348]
        at net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:406) [spigot.jar:git-Spigot-79a30d7-acbc348]
        at net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:679) [spigot.jar:git-Spigot-79a30d7-acbc348]
        at net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:577) [spigot.jar:git-Spigot-79a30d7-acbc348]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]

This error was caused by not having a description for a faction on the following setup:
Spigot 1.12.2
Dynmap 3.1 beta 3a
Factions 2.14.0
MassiveCore 2.14.0
WorldEdit 6.1.9
WorldGuard 6.2.2